### PR TITLE
Bugfix mutating annotation

### DIFF
--- a/dataclass_click/__init__.py
+++ b/dataclass_click/__init__.py
@@ -1,1 +1,2 @@
+from . import dataclass_click as _dataclass_click
 from .dataclass_click import *

--- a/dataclass_click/dataclass_click.py
+++ b/dataclass_click/dataclass_click.py
@@ -231,7 +231,10 @@ def _collect_click_annotations(arg_class: typing.Type[Arg]) -> dict[str, _Delaye
                 if isinstance(annotation, _DelayedCall):
                     annotations[key] = annotation
                     break
-    return annotations
+    return {
+        key: dataclasses.replace(annotation, kwargs=annotation.kwargs.copy())
+        for key, annotation in annotations.items()
+    }
 
 
 def _option_name(attribute_name: str) -> str:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -130,3 +130,19 @@ def test_inferred_required(args: dict[str, Any], expect: int):
         pass
 
     quick_run(main, expect_exit_code=expect)
+
+
+def test_dataclass_can_be_used_twice():
+    @dataclass
+    class Config:
+        imply_required: Annotated[int, option()]
+
+    @click.command()
+    @dataclass_click(Config)
+    def main_1(*args, **kwargs):
+        pass
+
+    @click.command()
+    @dataclass_click(Config)
+    def main_2(*args, **kwargs):
+        pass


### PR DESCRIPTION
Code was accidently mutating the annotation parmeters.  In future these should be made immutable by replacing dict with tuple of tuples, but will save that for a later version.  For now code simply copies the dict.