### PR TITLE
Introspection for inheritance

### DIFF
--- a/dataclass_click/dataclass_click.py
+++ b/dataclass_click/dataclass_click.py
@@ -9,7 +9,6 @@ __all__ = [
 
 import dataclasses
 import functools
-import inspect
 import operator
 import types
 import typing
@@ -225,7 +224,7 @@ def _collect_click_annotations(arg_class: typing.Type[Arg]) -> dict[str, _Delaye
     :param arg_class: Dataclass to analyze
     :return: A dictionary _DelayedCall keyed by attribute names"""
     annotations: dict[str, _DelayedCall] = {}
-    for key, value in inspect.get_annotations(arg_class).items():
+    for key, value in typing.get_type_hints(arg_class, include_extras=True).items():
         if typing.get_origin(value) is typing.Annotated:
             for annotation in typing.get_args(value):
                 if isinstance(annotation, _DelayedCall):

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -233,3 +233,23 @@ def test_keyword_name():
     results: list[CallRecord] = []
     quick_run(main)
     assert results == [((), {"foo": Config(bar=None)})]
+
+
+def test_inheritance():
+
+    @dataclass()
+    class Parent:
+        foo: Annotated[int | None, option()]
+
+    @dataclass
+    class Config(Parent):
+        bar: Annotated[int | None, option()]
+
+    @click.command()
+    @dataclass_click(Config)
+    def main(*args, **kwargs):
+        results.append((args, kwargs))
+
+    results: list[CallRecord] = []
+    quick_run(main, "--foo", "10", "--bar", "20")
+    assert results == [((Config(foo=10, bar=20), ), {})]


### PR DESCRIPTION
Fixed bug where inheritance of dataclasses was not properly explored.

This should now work as expected:

```python
    @dataclass()
    class Parent:
        foo: Annotated[int | None, option()]

    @dataclass
    class Config(Parent):
        bar: Annotated[int | None, option()]

    @click.command()
    @dataclass_click(Config)
    def main(*args, **kwargs):
        results.append((args, kwargs))
```