### PR TITLE
Fix decorator type hinting with overload

### DIFF
--- a/dataclass_click/dataclass_click.py
+++ b/dataclass_click/dataclass_click.py
@@ -15,7 +15,7 @@ import typing
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, overload, Concatenate
 from uuid import UUID
 
 import click
@@ -68,12 +68,27 @@ DONT_PASS = DontPassType.DONT_PASS
 This allows using the dataclass own default value instead of a click default."""
 
 
+@overload
+def dataclass_click(
+    arg_class: typing.Type[Arg],
+    *,
+    type_inferences: InferenceType | None = None,
+    factory: Callable[..., Arg] | None = None
+) -> Callable[[Callable[Concatenate[Arg, Param], RetType]], Callable[..., RetType]]:
+    ...
+
+
+@overload
 def dataclass_click(
         arg_class: typing.Type[Arg],
         *,
-        kw_name: str | None = None,
+        kw_name: str | None,
         type_inferences: InferenceType | None = None,
-        factory: Callable[..., Arg] | None = None) -> Callable[[Callable[[Arg], RetType]], Callable[..., RetType]]:
+        factory: Callable[..., Arg] | None = None) -> Callable[[Callable[Param, RetType]], Callable[Param, RetType]]:
+    ...
+
+
+def dataclass_click(arg_class, *, kw_name=None, type_inferences=None, factory=None):
     """Decorator to add options and arguments, collecting the results into a dataclass object instead of many kwargs
 
     arg_class can be any class type as long as annotations can be extracted with inspect.  Either the arg_class

--- a/tests/mypy_check.py
+++ b/tests/mypy_check.py
@@ -1,0 +1,41 @@
+"""
+This module exists to run MyPy checks.
+
+It must parse by python, there's unit test that imports it, and it gets checked by mypy, but it has no practical use.
+"""
+import decimal
+from dataclasses import dataclass
+from typing import Annotated
+
+import click
+
+from dataclass_click import register_type_inference, option, argument, dataclass_click
+
+
+class CustomParameterType(click.ParamType):
+    pass
+
+
+def register_something() -> None:
+    register_type_inference(decimal.Decimal, CustomParameterType())
+
+
+@dataclass
+class Config:
+    foo: Annotated[int, argument()]
+    bar: Annotated[str, argument(nargs=1)]
+    baz: Annotated[str | None, option()]
+    bob: Annotated[str | None, option("--bonno")]
+
+
+@click.command()
+@dataclass_click(Config)
+def main_a(config: Config):
+    ...
+
+
+@click.command()
+@dataclass_click(Config, kw_name="a")
+@click.option("--b")
+def main_b(b: str | None, a: Config):
+    ...

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -253,3 +253,9 @@ def test_inheritance():
     results: list[CallRecord] = []
     quick_run(main, "--foo", "10", "--bar", "20")
     assert results == [((Config(foo=10, bar=20), ), {})]
+
+
+def test_mypy_check_loads():
+    """Check that mypy_check.py will parse by python"""
+    from . import mypy_check
+    assert mypy_check


### PR DESCRIPTION
Mypy was throwing an error with KWarg form of the decoratror.  Fixed this using @overload

This should be fine now:
```python
@click.command()
@dataclass_click(BarType, kw_name="bar")
def main(bar: BarType):
    ...
```