### PR TITLE
Improved inference handling for multi types and nargs types

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -64,7 +64,7 @@ def test_multiple_types_can_be_inferred(inferrable_type, example_value_for_infer
 
     @dataclass
     class Config:
-        foo: Annotated[tuple[inferrable_type, ...], input_type]
+        foo: Annotated[tuple[inferrable_type, ...], input_type]  # type: ignore
 
     @click.command()
     @dataclass_click(Config)
@@ -88,7 +88,7 @@ def test_nargs_types_can_be_inferred(inferrable_type, example_value_for_inferrab
 
     @dataclass
     class Config:
-        foo: Annotated[tuple[inferrable_type, inferrable_type], input_type]
+        foo: Annotated[tuple[inferrable_type, inferrable_type], input_type]  # type: ignore
 
     @click.command()
     @dataclass_click(Config)


### PR DESCRIPTION
There was previously a bug with inference handling where `nargs=-1` or `multuple=True` or `is_flag` should mean not required, but this was not being assessed.  Required inference is now much more reliable.

Type inference handling where `nargs=-1` or `multiple=True` now knows to unbox the `tuple[foo, ...]` to `foo`.  Likewise inference handling for `nargs > 1` also knows to unbox tuple types.

Eg: this now works:

```python
@dataclass
class Foo:
    bar: Annotated[tuple[int, str], argument(nargs=2)]
```
